### PR TITLE
Updated docker file to use Debian 12 (bookworm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![Add repository on my Home Assistant][repository-badge]][repository-url]
 
-If you want to do add the repository manually:
+This is a TEMPORARY fork of this add-on, until it gets pulled back into the original add-on code hosted by @rwagoner.  To add the repository manually:
 1. In Home Assistant, navigate to Settings > Add-ons and click "Add-on Store"
 2. Click the three dots in the upper right > Repositories
 3. Enter the below URL and click Add

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ If you want to do add the repository manually:
 2. Click the three dots in the upper right > Repositories
 3. Enter the below URL and click Add
 ```
-https://github.com/excaliburpartners/hassio-addons
+https://github.com/jmantas/hassio-addons
 ```
 
 [repository-badge]: https://img.shields.io/badge/Add%20repository%20to%20my-Home%20Assistant-41BDF5?logo=home-assistant&style=for-the-badge
-[repository-url]: https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fexcaliburpartners%2Fhassio-addons
+[repository-url]: https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fjmantas%2Fhassio-addons

--- a/omnilink-bridge/Dockerfile
+++ b/omnilink-bridge/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/home-assistant/arm64-base-debian:bookworm
+ARG BUILD_FROM=homeassistant/arm64-base-debian:bookworm
 FROM mono:latest AS build
 
 RUN apt-get update && \

--- a/omnilink-bridge/Dockerfile
+++ b/omnilink-bridge/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=homeassistant/arm64-base-debian:bookworm
+ARG BUILD_FROM=homeassistant/aarch64-base-debian:bookworm
 # -----------------------------
 # Build Stage: Compile OmniLinkBridge
 # -----------------------------

--- a/omnilink-bridge/Dockerfile
+++ b/omnilink-bridge/Dockerfile
@@ -25,7 +25,7 @@ ARG BUILD_VERSION
 RUN major=`echo $BUILD_VERSION | cut -d. -f1` && \
     minor=`echo $BUILD_VERSION | cut -d. -f2` && \
     revision=`echo $BUILD_VERSION | cut -d. -f3` && \
-    git clone --depth 1 -b $major.$minor.$revision https://github.com/jmantas/OmniLinkBridge.git /build
+    git clone --depth 1 -b $major.$minor.$revision https://github.com/excaliburpartners/OmniLinkBridge.git /build
 
 WORKDIR /build
 

--- a/omnilink-bridge/Dockerfile
+++ b/omnilink-bridge/Dockerfile
@@ -8,7 +8,7 @@ ARG BUILD_VERSION
 RUN major=`echo $BUILD_VERSION | cut -d. -f1` \
     && minor=`echo $BUILD_VERSION | cut -d. -f2` \
     && revision=`echo $BUILD_VERSION | cut -d. -f3` \
-    && git clone --depth 1 -b $major.$minor.$revision https://github.com/excaliburpartners/OmniLinkBridge.git /build
+    && git clone --depth 1 -b $major.$minor.$revision https://github.com/jmantas/OmniLinkBridge.git /build
 
 WORKDIR /build
 

--- a/omnilink-bridge/Dockerfile
+++ b/omnilink-bridge/Dockerfile
@@ -1,41 +1,64 @@
-ARG BUILD_FROM=homeassistant/arm64-base-debian:bookworm
-FROM mono:latest AS build
+# -----------------------------
+# Build Stage: Compile OmniLinkBridge
+# -----------------------------
+FROM debian:bookworm-slim AS build
 
+# Install tools and mono from official repository
 RUN apt-get update && \
-  apt-get install -y git
+    apt-get install -y --no-install-recommends \
+        gnupg dirmngr ca-certificates apt-transport-https curl git
 
+# Add Mono GPG key and repo (only stable-buster exists)
+RUN gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys \
+        3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
+    gpg --batch --export --armor 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF > \
+        /etc/apt/trusted.gpg.d/mono.gpg.asc && \
+    echo "deb https://download.mono-project.com/repo/debian stable-buster main" > \
+        /etc/apt/sources.list.d/mono-official-stable.list &&\
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        mono-complete msbuild nuget
+
+# Download source code from GitHub using the version tag
 ARG BUILD_VERSION
-RUN major=`echo $BUILD_VERSION | cut -d. -f1` \
-    && minor=`echo $BUILD_VERSION | cut -d. -f2` \
-    && revision=`echo $BUILD_VERSION | cut -d. -f3` \
-    && git clone --depth 1 -b $major.$minor.$revision https://github.com/jmantas/OmniLinkBridge.git /build
+RUN major=`echo $BUILD_VERSION | cut -d. -f1` && \
+    minor=`echo $BUILD_VERSION | cut -d. -f2` && \
+    revision=`echo $BUILD_VERSION | cut -d. -f3` && \
+    git clone --depth 1 -b $major.$minor.$revision https://github.com/jmantas/OmniLinkBridge.git /build
 
 WORKDIR /build
 
-RUN nuget restore /build/OmniLinkBridge.sln
-RUN msbuild /build/OmniLinkBridge.sln /t:Build /p:Configuration=Release
-RUN mv /build/OmniLinkBridge/bin/Release /app
+# Restore dependencies and build project
+RUN nuget restore /build/OmniLinkBridge.sln && \
+    msbuild /build/OmniLinkBridge.sln /t:Build /p:Configuration=Release && \
+    mv /build/OmniLinkBridge/bin/Release /app
 
+# ------------------------------------------------
+# Runtime Stage: Final Home Assistant add-on image
+# ------------------------------------------------
+ARG BUILD_FROM=homeassistant/arm64-base-debian:bookworm
 FROM $BUILD_FROM AS runtime
 
-# Copy root filesystem
+# Copy root filesystem for Home Assistant add-on environment
 COPY rootfs /
 
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends gnupg dirmngr ca-certificates \
-  && rm -rf /var/lib/apt/lists/* \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-  && gpg --batch --export --armor 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF > /etc/apt/trusted.gpg.d/mono.gpg.asc \
-  && gpgconf --kill all \
-  && rm -rf "$GNUPGHOME" \
-  && apt-key list | grep Xamarin \
-  && apt-get purge -y --auto-remove gnupg dirmngr
+# Install Mono runtime from the official repository
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gnupg dirmngr ca-certificates apt-transport-https && \
+    rm -rf /var/lib/apt/lists/* && \
+    export GNUPGHOME="$(mktemp -d)" && \
+    gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
+    gpg --batch --export --armor 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF > /etc/apt/trusted.gpg.d/mono.gpg.asc && \
+    echo "deb https://download.mono-project.com/repo/debian stable-bookworm main" > \
+         /etc/apt/sources.list.d/mono-official-stable.list && \
+    apt-get update && \
+    apt-get install -y mono-complete && \
+    rm -rf /var/lib/apt/lists/* /tmp/*
 
-RUN echo "deb https://download.mono-project.com/repo/debian stable-bookworm main" > /etc/apt/sources.list.d/mono-official-stable.list \
-  && apt-get update \
-  && apt-get install -y mono-complete \
-  && rm -rf /var/lib/apt/lists/* /tmp/*
+# Cleanup GPG tools
+RUN gpgconf --kill all && \
+    rm -rf "$GNUPGHOME" && \
+    apt-get purge -y --auto-remove gnupg dirmngr
 
 WORKDIR /app
 

--- a/omnilink-bridge/Dockerfile
+++ b/omnilink-bridge/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update \
   && apt-key list | grep Xamarin \
   && apt-get purge -y --auto-remove gnupg dirmngr
 
-RUN echo "deb https://download.mono-project.com/repo/debian stable-buster main" > /etc/apt/sources.list.d/mono-official-stable.list \
+RUN echo "deb https://download.mono-project.com/repo/debian stable-bookworm main" > /etc/apt/sources.list.d/mono-official-stable.list \
   && apt-get update \
   && apt-get install -y mono-complete \
   && rm -rf /var/lib/apt/lists/* /tmp/*

--- a/omnilink-bridge/Dockerfile
+++ b/omnilink-bridge/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=homeassistant/aarch64-base-debian:bookworm
+ARG BUILD_FROM=ghcr.io/home-assistant/arm64-base-debian:bookworm
 FROM mono:latest AS build
 
 RUN apt-get update && \

--- a/omnilink-bridge/Dockerfile
+++ b/omnilink-bridge/Dockerfile
@@ -50,7 +50,7 @@ RUN apt-get update && \
     export GNUPGHOME="$(mktemp -d)" && \
     gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
     gpg --batch --export --armor 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF > /etc/apt/trusted.gpg.d/mono.gpg.asc && \
-    echo "deb https://download.mono-project.com/repo/debian stable-bookworm main" > \
+    echo "deb https://download.mono-project.com/repo/debian stable-buster main" > \
          /etc/apt/sources.list.d/mono-official-stable.list && \
     apt-get update && \
     apt-get install -y mono-complete && \

--- a/omnilink-bridge/Dockerfile
+++ b/omnilink-bridge/Dockerfile
@@ -1,3 +1,4 @@
+ARG BUILD_FROM=homeassistant/arm64-base-debian:bookworm
 # -----------------------------
 # Build Stage: Compile OmniLinkBridge
 # -----------------------------
@@ -36,7 +37,7 @@ RUN nuget restore /build/OmniLinkBridge.sln && \
 # ------------------------------------------------
 # Runtime Stage: Final Home Assistant add-on image
 # ------------------------------------------------
-ARG BUILD_FROM=homeassistant/arm64-base-debian:bookworm
+
 FROM $BUILD_FROM AS runtime
 
 # Copy root filesystem for Home Assistant add-on environment

--- a/omnilink-bridge/Dockerfile
+++ b/omnilink-bridge/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM
+ARG BUILD_FROM=homeassistant/aarch64-base-debian:bookworm
 FROM mono:latest AS build
 
 RUN apt-get update && \

--- a/omnilink-bridge/build.yaml
+++ b/omnilink-bridge/build.yaml
@@ -3,4 +3,4 @@ build_from:
   aarch64: homeassistant/aarch64-base-debian:bookworm
   amd64: homeassistant/amd64-base-debian:bookworm
   i386: homeassistant/i386-base-debian:bookworm
-  arm64: homeassistant/arm64-base-debian:bookworm
+ 

--- a/omnilink-bridge/build.yaml
+++ b/omnilink-bridge/build.yaml
@@ -1,5 +1,5 @@
 build_from:
-  armv7: homeassistant/armv7-base-debian:buster
-  aarch64: homeassistant/aarch64-base-debian:buster
-  amd64: homeassistant/amd64-base-debian:buster
-  i386: homeassistant/i386-base-debian:buster
+  armv7: homeassistant/armv7-base-debian:bookworm
+  aarch64: homeassistant/aarch64-base-debian:bookworm
+  amd64: homeassistant/amd64-base-debian:bookworm
+  i386: homeassistant/i386-base-debian:bookworm

--- a/omnilink-bridge/build.yaml
+++ b/omnilink-bridge/build.yaml
@@ -1,6 +1,6 @@
 build_from:
-  armv7: ghcr.io/home-assistant/armv7-base-debian:bookworm
-  aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
-  amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
-  i386: ghcr.io/home-assistant/i386-base-debian:bookworm
-  arm64: ghcr.io/home-assistant/arm64-base-debian:bookworm
+  armv7: homeassistant/armv7-base-debian:bookworm
+  aarch64: homeassistant/aarch64-base-debian:bookworm
+  amd64: homeassistant/amd64-base-debian:bookworm
+  i386: homeassistant/i386-base-debian:bookworm
+  arm64: homeassistant/arm64-base-debian:bookworm

--- a/omnilink-bridge/build.yaml
+++ b/omnilink-bridge/build.yaml
@@ -3,3 +3,4 @@ build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
   amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
   i386: ghcr.io/home-assistant/i386-base-debian:bookworm
+  arm64: ghcr.io/home-assistant/arm64-base-debian:bookworm

--- a/omnilink-bridge/build.yaml
+++ b/omnilink-bridge/build.yaml
@@ -1,5 +1,5 @@
 build_from:
-  armv7: homeassistant/armv7-base-debian:bookworm
-  aarch64: homeassistant/aarch64-base-debian:bookworm
-  amd64: homeassistant/amd64-base-debian:bookworm
-  i386: homeassistant/i386-base-debian:bookworm
+  armv7: ghcr.io/home-assistant/armv7-base-debian:bookworm
+  aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
+  amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
+  i386: ghcr.io/home-assistant/i386-base-debian:bookworm

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
   "name": "Excalibur Partners, LLC Add-ons (JM test)",
   "url": "https://github.com/jmantas/hassio-addons",
-  "maintainer": "Ryan Wagoner <rwagoner@excalibur-partners.com>"
+  "maintainer": "Jesus Mantas <jmantas1@gmail.com>"
 }

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
-  "name": "Excalibur Partners, LLC Add-ons",
-  "url": "https://github.com/excaliburpartners/hassio-addons",
+  "name": "Excalibur Partners, LLC Add-ons (JM test)",
+  "url": "https://github.com/jmantas/hassio-addons",
   "maintainer": "Ryan Wagoner <rwagoner@excalibur-partners.com>"
 }


### PR DESCRIPTION
The current version of the add-on fails when trying to install it. It looks for buster image and it's now archived.  This solutions uses bookworm base image from home assistant, and still pulls the stable-debian from mono, compiles it and creates the run time. 

I updated build.yaml to bookworm, and remade the dockerfile for both build and run time using bookworm base and still buster from mono (because bookworm is not available in mono). 

This was created with AI guidance that may or may not be correct, but so far the installation worked without issues. I standardized on && / at the end of each line for clearer indentation (per AI recommendation). 

You can ignore the changed to readme and repository files - Ill delete those once the pull is committed, they were in case people use the repository at https://github.com/jmantas/hassio-addons to make clear that it meant to be temporary and points to the repository url. 

Let me know if questions. 

Thanks!
JM

